### PR TITLE
Add 'Inteligência Artificial' skills section

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,16 @@
 
                     </ul>
 
+                    <h2 class="app-body__subtitle">Inteligência Artificial</h2>
+                    <ul class="skills-list">
+
+                        <li>Prompt Engineering</li>
+                        <li>RAG (Retrieval-Augmented Generation)</li>
+                        <li>Integração de IA em projetos</li>
+                        <li>Ferramentas de IA no desenvolvimento (OpenAI Codex, GitHub Copilot, Windsurf, Google Antigravity)</li>
+
+                    </ul>
+
                     <h2 class="app-body__subtitle">Desenvolvimento Front-end</h2>
                     <ul class="skills-list">
                         


### PR DESCRIPTION
### Motivation

- Add an explicit “Inteligência Artificial” subsection to the Habilidades area to surface AI-related capabilities and tooling. 
- Keep the AI section near other technical skill groups by inserting it after `Desenvolvimento Back-end`. 

### Description

- Updated `index.html` to insert `<h2 class="app-body__subtitle">Inteligência Artificial</h2>` and a corresponding `<ul class="skills-list">` with items for `Prompt Engineering`, `RAG (Retrieval-Augmented Generation)`, `Integração de IA em projetos`, and common AI tools. 
- Ensured the new block is placed immediately after the `Desenvolvimento Back-end` skills list and before `Desenvolvimento Front-end`. 
- Committed the change to the repository with the message `Add AI skills section`.

### Testing

- Launched a local static server with `python -m http.server` and captured a page screenshot via Playwright to visually verify the new section, which succeeded. 
- Earlier Playwright attempts timed out, but a final run produced the screenshot artifact confirming the section placement and content. 
- No unit or integration tests were applicable or run for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695334e81648832bae02a296d2bea6df)